### PR TITLE
Comment out non error/exception messages

### DIFF
--- a/src/SerfIoThread.cpp
+++ b/src/SerfIoThread.cpp
@@ -195,7 +195,7 @@ bool SerfIoThread::sendData(RequestHeader &hdr, T &body, C *channel, uint64_t &s
     bool result = (send(m_socket, ss.str().data(), ss.str().size(), 0) != -1);
     if (result) {
         m_channels[hdr.Seq] = channel;
-        std::cout << "sendData() with Seq=" << hdr.Seq << std::endl;
+        // std::cout << "sendData() with Seq=" << hdr.Seq << std::endl;
         seq = hdr.Seq;
     }
 
@@ -213,7 +213,7 @@ bool SerfIoThread::sendData(RequestHeader &hdr, C *channel, uint64_t &seq) {
     bool result = (send(m_socket, ss.str().data(), ss.str().size(), 0) != -1);
     if (result) {
         m_channels[hdr.Seq] = channel;
-        std::cout << "sendData() with Seq=" << hdr.Seq << std::endl;
+        // std::cout << "sendData() with Seq=" << hdr.Seq << std::endl;
         seq = hdr.Seq;
     }
 


### PR DESCRIPTION
Found these messages being output during normal processing.  longer term it might be nice to be able to configure the library with a log level and dynamically include messages.

In my case, our service is started by systemd and these messages were filling up the journal.  I didn't want to suppress stdout nor did i want to send these messages to a separate file so it was easiest to just comment them out - thought you may want to do the same